### PR TITLE
module: use the header in RTT_ROOT if possible

### DIFF
--- a/software/programs/SConstruct
+++ b/software/programs/SConstruct
@@ -7,7 +7,15 @@ sconstruct = File('SConstruct')
 fn = sconstruct.rfile()
 name = fn.name
 building_dir = os.path.dirname(fn.abspath)
-RTT_ROOT = os.path.join(building_dir, '.', 'rt-thread')
+
+if os.getenv('RTT_ROOT'):
+    RTT_ROOT = os.getenv('RTT_ROOT')
+else:
+    RTT_ROOT = os.path.join(building_dir, '.', 'rt-thread')
+
+RTT_RTGUI = os.getenv('RTT_RTGUI')
+if not RTT_RTGUI:
+    RTT_RTGUI = RTT_ROOT + '/components/rtgui/'
 
 sys.path = sys.path + [os.path.join(RTT_ROOT, 'tools')]
 from building import *
@@ -47,7 +55,7 @@ env = Environment(tools = ['mingw'],
                 RTT_ROOT + '/components/dfs', 
                 RTT_ROOT + '/components/dfs/include',
                 RTT_ROOT + '/components/libc/newlib',
-		RTT_ROOT + '/components/rtgui/include'
+                RTT_RTGUI + '/include'
                 ])
 env.PrependENVPath('PATH', rtconfig.EXEC_PATH)
 


### PR DESCRIPTION
There is no guarantee that the headers within
software/programs/rt-thread is always up-to-date. So use the header in
RTT_ROOT if possible. It will make use of RTT_RTGUI as well.
