### PR TITLE
Update stm32f4xx_eth.c

### DIFF
--- a/software/realtouch/drivers/stm32f4xx_eth.c
+++ b/software/realtouch/drivers/stm32f4xx_eth.c
@@ -3901,7 +3901,7 @@ static void phy_monitor_thread_entry(void *parameter)
 
         phy_speed_new = 0;
 
-        if(status & (PHY_AutoNego_Complete | PHY_Linked_Status))
+        if((status & PHY_AutoNego_Complete) && (status & PHY_Linked_Status))
         {
             uint16_t SR;
 


### PR DESCRIPTION
在PHY_AutoNego_Complete成功之前，PHY_Linked_Status的状态是没有意义的。
